### PR TITLE
Add the --tag option

### DIFF
--- a/ec2-expire-snapshots
+++ b/ec2-expire-snapshots
@@ -30,6 +30,7 @@ my $use_iam_role               = 0;
 my $region                     = undef;
 my $ec2_endpoint               = undef;
 my $volume_id_in_tag           = undef;
+my $tag                        = undef;
 my $delete_delay               = undef;
 
 my $force_delete_all           = undef;
@@ -61,6 +62,7 @@ GetOptions(
   'use-iam-role'                 => \$use_iam_role,
   'region=s'                     => \$region,
   'volume-id-in-tag=s'           => \$volume_id_in_tag,
+  'tag=s'                        => \$tag,
   'delete-delay=i'               => \$delete_delay,
 
   'force-delete-all'             => \$force_delete_all,
@@ -117,7 +119,7 @@ my $ec2 = Net::Amazon::EC2->new(
     # ($Debug ? (debug => 1) : ()),
   );
 
-my $snapshots_for_volumes = snapshots_for_volumes($ec2,$volume_id_in_tag,@volume_ids);
+my $snapshots_for_volumes = snapshots_for_volumes($ec2,$volume_id_in_tag,$tag,@volume_ids);
 for my $volume_id ( @volume_ids ) {
     expire_snapshots_for_volume($ec2, $volume_id,
                                 $snapshots_for_volumes->{$volume_id},
@@ -171,10 +173,11 @@ sub read_awssecret {
 
 # Return hash of { volume_id => [ snapshot, snapshot, ... ], ... }
 sub snapshots_for_volumes {
-    my ($ec2,$volume_id_in_tag,@volume_ids) = @_;
+    my ($ec2,$volume_id_in_tag,$tag,@volume_ids) = @_;
 
     my @filters;
     $volume_id_in_tag and push @filters, ['tag-key', $volume_id_in_tag];
+    $tag              and push @filters, ["tag:$tag", ''];
     @volume_ids       and push @filters, ['volume-id', @volume_ids];
 
     $Debug and warn "$Prog: Retrieving snapshot list\n";
@@ -586,6 +589,14 @@ replacing the volume-id that is returned by the API. The common
 use is for when snapshots are copied across regions. This is so
 a consistent expiration schedule can be kept, without regards to
 the new volume-id generated each time a copy is made.
+
+=item C<--tag TAGNAME>
+
+Specifies the name of a tag that must be present on the snapshot for it to
+be selected for expiration. It's useful, for example, if you tag all your
+backup snapshots with a tag like 'backup', to avoid expiring snapshots taken
+for other purposes. In this case, select only backup snapshots by specifying
+the option C<--tag backup>.
 
 =item C<--delete-delay DELAY_IN_SECONDS>
 


### PR DESCRIPTION
This option specifies the name of a tag that must be present on the
snapshot for it to be selected for expiration. It's useful, for
example, if you tag all your backup snapshots with a tag like
'backup', to avoid expiring snapshots taken for other purposes.