### PR TITLE
Fix Ubuntu 18.04 build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,4 +5,4 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 PKGDIR=debian/ec2-expire-snapshots
 
 build/ec2-expire-snapshots:: 
-	 pod2man --release= ec2-expire-snapshots > ec2-expire-snapshots.1
+	 pod2man ec2-expire-snapshots > ec2-expire-snapshots.1


### PR DESCRIPTION
Had to remove the pod2man `--release` argument. Now you can build an Ubuntu 18.04 package by running `dpkg-buildpackage -b -uc -us`.
